### PR TITLE
Refactor render method

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
+    "prop-types": "^15.5.10",
     "react": "^15.6.1"
   },
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, isValidElement, Children, createElement } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 // base class that detects offline/online changes
 class Base extends Component {
@@ -11,31 +12,6 @@ class Base extends Component {
     this.goOnline = this.goOnline.bind(this);
     this.goOffline = this.goOffline.bind(this);
     this.handleDebugKeydown = this.handleDebugKeydown.bind(this);
-  }
-  renderChildren() {
-    const { children } = this.props;
-    let { wrapperType } = this.props;
-
-    // usual case: one child that is a react Element
-    if (React.isValidElement(children)) { return children; }
-
-    // no children
-    if (!children) { return null; }
-
-    // string children, multiple children, or something else
-    const childrenArray = Children.toArray(children);
-    const firstChild = childrenArray[0];
-    // use wrapperType if specified
-    if (!wrapperType) {
-      if (typeof firstChild === 'string' || firstChild.type === 'span') {
-        // use span for string or span children
-        wrapperType = 'span';
-      } else {
-        // fallback on div
-        wrapperType = 'div';
-      }
-    }
-    return createElement(wrapperType, {}, ...childrenArray);
   }
   goOnline() {
     this.setState({ online: true });
@@ -63,14 +39,18 @@ class Base extends Component {
   }
 }
 
+Base.propTypes = {
+  children: PropTypes.element.isRequired
+};
+
 export class Online extends Base {
   render() {
-    return this.state.online ? this.renderChildren() : null;
+    return this.state.online && this.props.children;
   }
 }
 
 export class Offline extends Base {
   render() {
-    return !this.state.online ? this.renderChildren() : null;
+    return !this.state.online && this.props.children;
   }
 }


### PR DESCRIPTION
Thank you for sharing this project 👍 

This Pull Request addresses a bug I noticed with the `renderChildren` logic.

If we had the below code, it would be wrapped in a `<div />` tag.
```jsx
<Online>
  <a href="#">Hello</a>
</Online>

// ...becomes

<div><a href="#">Hello</a></div>
```
Is this intentional? Shouldn't all inline tags be wrapped in a `<span />` tag? And we might also want to document the `wrapperType` prop.

To me, the logic is starting to get more complicated than it has to.

I think we should leave it to the user of `react-detect-offline` to decide how they want to render their children.