### PR TITLE
Add pollingUrl and pollingInterval props to Base component

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,22 @@ Check out [chris.bolin.co/offline](https://chris.bolin.co/offline) for a simple 
 
 **Note:** `Online` and `Offline` are mutually exclusive; if one is rendering, the other will not be.
 
+### Props
+
+`<Online/>` and `<Offline/>` both accept the following props:
+
+| Prop              | Type   | Default                       |
+| ----------------- | ------ | ----------------------------- |
+| `pollingInterval` | Number | 5000                          |
+| `pollingUrl`      | String | `https://ipv4.icanhazip.com/` | 
+
 ### Browser Support
 
 The [web spec](https://developer.mozilla.org/en-US/docs/Online_and_offline_events) we rely on is supported by IE 9+, Chrome 14+, Firefox 41+, and Safari 5+ - that's [94% of worldwide (98% of US)](http://caniuse.com/#feat=online-status) browser traffic.
 
 ### Example Uses
 
-- Use `Offline` to remind users they might need to connect to complete certain actions.
-- Use `Online` to let readers know the page is available offline.
-- Use `Online` to hide links or other content that is irrelevant when offline.
-- idk, use your dang imagination.
+ -Use `Offline` to remind users they might need to connect to complete certain actions.
+ -Use `Online` to let readers know the page is available offline.
+ -Use `Online` to hide links or other content that is irrelevant when offline.
+ -idk, use your dang imagination.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "enzyme": "^2.9.1",
     "enzyme-to-json": "^1.5.1",
     "jest": "^21.0.1",
+    "prop-types": "^15.6.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1"

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -14,7 +14,21 @@ Array [
 `;
 
 exports[`Offline should render children when offline 1`] = `
-<Offline>
+<Offline
+  pollingInterval={5000}
+  pollingUrl="https://ipv4.icanhazip.com/"
+>
+  <h1>
+    Hello World
+  </h1>
+</Offline>
+`;
+
+exports[`Offline should render children when offline and using a custom polling URL 1`] = `
+<Offline
+  pollingInterval={5000}
+  pollingUrl="https://www.google.com/"
+>
   <h1>
     Hello World
   </h1>
@@ -35,7 +49,21 @@ Array [
 `;
 
 exports[`Online should render children when online 1`] = `
-<Online>
+<Online
+  pollingInterval={5000}
+  pollingUrl="https://ipv4.icanhazip.com/"
+>
+  <h1>
+    Hello World
+  </h1>
+</Online>
+`;
+
+exports[`Online should render children when online and using a custom polling URL 1`] = `
+<Online
+  pollingInterval={5000}
+  pollingUrl="https://www.google.com/"
+>
   <h1>
     Hello World
   </h1>

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,6 @@ class Base extends Component {
       }, pollingInterval);
     } 
     else {
-      console.warn(process.env);
       console.warn('A pollingUrl must be defined in order to support browsers that do not properly implement offline events.');
     }
   }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -30,6 +30,17 @@ describe("Online", () => {
 
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+  
+  it("should render children when online and using a custom polling URL", () => {
+    const wrapper = mount(
+      <Online pollingUrl="https://www.google.com/">
+        <h1>Hello World</h1>
+      </Online>
+    );
+
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
 
   it("should not render children when offline", () => {
     Object.defineProperty(navigator, "onLine", { value: false });
@@ -42,6 +53,19 @@ describe("Online", () => {
 
     expect(wrapper.html()).toBeNull();
   });
+  
+  it("should not render children when offline and using a custom polling URL", () => {
+    Object.defineProperty(navigator, "onLine", { value: false });
+
+    const wrapper = mount(
+      <Online pollingUrl="https://www.google.com/">
+        <h1>Hello World</h1>
+      </Online>
+    );
+
+    expect(wrapper.html()).toBeNull();
+  });
+
 
   it("should not render children when going from online to offline", () => {
     const wrapper = mount(
@@ -85,12 +109,35 @@ describe("Offline", () => {
 
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+  
+  it("should render children when offline and using a custom polling URL", () => {
+    const wrapper = mount(
+      <Offline pollingUrl="https://www.google.com/">
+        <h1>Hello World</h1>
+      </Offline>
+    );
+
+    expect(toJSON(wrapper)).toMatchSnapshot();
+  });
+
 
   it("should not render children when online", () => {
     Object.defineProperty(navigator, "onLine", { value: true });
 
     const wrapper = mount(
       <Offline>
+        <h1>Hello World</h1>
+      </Offline>
+    );
+
+    expect(wrapper.html()).toBeNull();
+  });
+  
+  it("should not render children when online and using a custom polling URL", () => {
+    Object.defineProperty(navigator, "onLine", { value: true });
+
+    const wrapper = mount(
+      <Offline pollingUrl="https://www.google.com/">
         <h1>Hello World</h1>
       </Offline>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,6 +1186,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fbjs@^0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
@@ -2490,6 +2502,14 @@ prop-types@^15.5.10:
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This should resolve #7.

I ended up also adding the prop for interval as well. I realized that internally we want to be able to control that in addition to the URL.

For the console warning if no pollingInterval is defined, there is not currently an environment check on it. If it turns out someone wants to disable that completely, we could add an env check... but I think we agree it's probably better to leave it as is for now. 