### PR TITLE
Switched from GET to HEAD Requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44,16 +44,17 @@ var ping = function ping(_ref) {
 
     xhr.onerror = isOffline;
     xhr.ontimeout = isOffline;
-    xhr.onload = function () {
-      var response = xhr.responseText.trim();
-      if (!response) {
-        isOffline();
-      } else {
-        isOnline();
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === xhr.HEADERS_RECEIVED) {
+        if (xhr.status >= 200 && xhr.status < 400) {
+          isOnline();
+        } else {
+          isOffline();
+        }
       }
     };
 
-    xhr.open("GET", url);
+    xhr.open("HEAD", url);
     xhr.timeout = timeout;
     xhr.send();
   });

--- a/src/index.js
+++ b/src/index.js
@@ -15,16 +15,17 @@ const ping = ({ url, timeout }) => {
 
     xhr.onerror = isOffline;
     xhr.ontimeout = isOffline;
-    xhr.onload = () => {
-      const response = xhr.responseText.trim();
-      if (!response) {
-        isOffline();
-      } else {
-        isOnline();
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === xhr.HEADERS_RECEIVED) {
+        if (xhr.status >= 200 && xhr.status < 400) {
+          isOnline();
+        } else {
+          isOffline();
+        }
       }
     };
 
-    xhr.open("GET", url);
+    xhr.open("HEAD", url);
     xhr.timeout = timeout;
     xhr.send();
   });


### PR DESCRIPTION
This PR simply switches from `GET` to `HEAD` requests. For the purposes of this module, the actual server response is meaningless and therefore `HEAD` is better suited, not only does it generate a faster/lighter response, it also reduces the strain on the server.

I've included checks for the status code (if >= 400 it will return offline), but I'm not sure if that's useful as a 400/500 response would still mean the client is online - however, because previously the code was checking for a non-falsy responseText I decided to keep it.